### PR TITLE
Deploy manifests with kubectl provider

### DIFF
--- a/deploy/nginx.yaml
+++ b/deploy/nginx.yaml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: nginx
-  replicas: 4 # tells deployment to run 3 pods matching the template
+  replicas: 2 # tells deployment to run 2 pods matching the template
   template:
     metadata:
       labels:


### PR DESCRIPTION
* Set number of replicas on the Nginx deployment to 2, as 4 do not fit in a t3.small instance.