### PR TITLE
K8s provider has to be configured

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -8,6 +8,13 @@ data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
 }
 
+# See: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1280#issuecomment-804499461
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
 provider "kubectl" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.21"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.12"
+    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "~> 1.14"


### PR DESCRIPTION
* Otherwise creation of aws-auth ConfigMap fails, resulting in a broken cluster.